### PR TITLE
Remove usage of Go vendor mode from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,16 @@ test-in-docker: build-container
 
 # TODO: This should build for the current arch, not linux
 build:
-	$(GO) build -i -mod=vendor -o ./dist/datasource/${DSNAME}_linux_amd64 -tags netgo -ldflags '-w' ./pkg
+	$(GO) build -i -o ./dist/datasource/${DSNAME}_linux_amd64 -tags netgo -ldflags '-w' ./pkg
 
 build-darwin:
-	$(GO) build -mod=vendor -o ./dist/datasource/${DSNAME}_darwin_amd64 -tags netgo -ldflags '-w' ./pkg
+	$(GO) build -o ./dist/datasource/${DSNAME}_darwin_amd64 -tags netgo -ldflags '-w' ./pkg
 
 build-dev:
-	$(GO) build -mod=vendor -o ./dist/datasource/${DSNAME}_linux_amd64 ./pkg
+	$(GO) build -o ./dist/datasource/${DSNAME}_linux_amd64 ./pkg
 
 build-win:
-	$(GO) build -mod=vendor -o ./dist/datasource/${DSNAME}_windows_amd64.exe -tags netgo -ldflags '-w' ./pkg
+	$(GO) build -o ./dist/datasource/${DSNAME}_windows_amd64.exe -tags netgo -ldflags '-w' ./pkg
 
 build-in-circleci: build-in-circleci-linux build-in-circleci-windows
 


### PR DESCRIPTION
Remove usage of Go vendor mode from Makefile, as suggested by Kyle. The reason to remove it is that we don't check the vendor tree into Git, so every developer would have to rebuild it in any case.