### PR TITLE
Move version property to info.version

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -4,10 +4,8 @@
   "id": "gel",
   "executable": "gel",
   "backend": true,
-
-  "version": "0.4.0",
-
   "info": {
+    "version": "0.4.0",
     "author": {
       "name": "Grafana Project",
       "url": "https://grafana.com"

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -5,7 +5,7 @@
   "executable": "gel",
   "backend": true,
   "info": {
-    "version": "0.4.0",
+    "version": "0.5.0",
     "author": {
       "name": "Grafana Project",
       "url": "https://grafana.com"


### PR DESCRIPTION
Move the version property to info.version, for compatibility with build pipeline tool (breaks currently) etc.

I don't know for sure what we've standardized on, but I think I started using info.version because [grafana/plugins-bundled/internal/input-datasource](https://github.com/grafana/grafana/blob/master/plugins-bundled/internal/input-datasource/src/plugin.json) does it. I don't really care where we put the property, we just need to standardize on something :) If we fix it here, I don't have to fix the build pipeline tool.