### PR TITLE
experiment: NumberSet in table format from datasource queries

### DIFF
--- a/pkg/transform.go
+++ b/pkg/transform.go
@@ -3,10 +3,8 @@ package main
 import (
 	"encoding/json"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/grafana/gel-app/pkg/gelpoc"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -19,7 +17,6 @@ func (gp *GELPlugin) TransformData(ctx context.Context, req *backend.QueryDataRe
 	svc := gelpoc.Service{
 		CallBack: callBack,
 	}
-	log.DefaultLogger.Debug(spew.Sdump(req))
 	// Build the pipeline from the request, checking for ordering issues (e.g. loops)
 	// and parsing graph nodes from the queries.
 	pipeline, err := svc.BuildPipeline(req.Queries)


### PR DESCRIPTION
Accept table input as a numberSet as well as time series. Would need more testing and code cleanup, this duck typing makes me a bit uneasy, in particular if used in the context of alerting. 

Would be better to be able to take type hints from the query, maybe universal extraction from what shows up as "Format as" in this data source (like instant vector in prom).

![image](https://user-images.githubusercontent.com/1692624/94945489-bdc8c380-04a8-11eb-896b-c49a379506dd.png)


![image](https://user-images.githubusercontent.com/1692624/94945498-c15c4a80-04a8-11eb-801c-e3b876de5d32.png)
